### PR TITLE
Add MANIFEST.in to include LICENSE

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+include README.md
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]


### PR DESCRIPTION
* Add manifest file to make sure LICENSE is included in the package.
* I've tested running `python setup.py sdist` before and after the change. The diff in the tarball is only two files:
```
> LICENSE
> MANIFEST.in
```
* I've also reproduced the original error while installing the tarball after local build. Then, after applying the fix in this PR, again built locally and tested installing. No more error. :tada: 

fixes #2 

**Build log when installing the tarball built from the master branch.**
```
(pyqwikswitch) martin@martin-ThinkPad-T460s:~/Dev/pyqwikswitch$ pip install ~/Skrivbord/test/pyqwikswitch-0.7.tar.gz 
Processing /home/martin/Skrivbord/test/pyqwikswitch-0.7.tar.gz
Collecting attrs (from pyqwikswitch==0.7)
  Using cached attrs-17.4.0-py2.py3-none-any.whl
Collecting requests (from pyqwikswitch==0.7)
  Using cached requests-2.18.4-py2.py3-none-any.whl
Collecting idna<2.7,>=2.5 (from requests->pyqwikswitch==0.7)
  Using cached idna-2.6-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests->pyqwikswitch==0.7)
  Using cached certifi-2018.1.18-py2.py3-none-any.whl
Collecting chardet<3.1.0,>=3.0.2 (from requests->pyqwikswitch==0.7)
  Using cached chardet-3.0.4-py2.py3-none-any.whl
Collecting urllib3<1.23,>=1.21.1 (from requests->pyqwikswitch==0.7)
  Using cached urllib3-1.22-py2.py3-none-any.whl
Building wheels for collected packages: pyqwikswitch
  Running setup.py bdist_wheel for pyqwikswitch ... error
  Complete output from command /home/martin/.virtualenvs/pyqwikswitch/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/tmp/pip-req-build-7gnzyxqo/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-wkrbd3jv --python-tag cp36:
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib
  creating build/lib/pyqwikswitch
  copying pyqwikswitch/qwikswitch.py -> build/lib/pyqwikswitch
  copying pyqwikswitch/__init__.py -> build/lib/pyqwikswitch
  copying pyqwikswitch/threaded.py -> build/lib/pyqwikswitch
  copying pyqwikswitch/async_.py -> build/lib/pyqwikswitch
  installing to build/bdist.linux-x86_64/wheel
  running install
  running install_lib
  creating build/bdist.linux-x86_64
  creating build/bdist.linux-x86_64/wheel
  creating build/bdist.linux-x86_64/wheel/pyqwikswitch
  copying build/lib/pyqwikswitch/qwikswitch.py -> build/bdist.linux-x86_64/wheel/pyqwikswitch
  copying build/lib/pyqwikswitch/__init__.py -> build/bdist.linux-x86_64/wheel/pyqwikswitch
  copying build/lib/pyqwikswitch/threaded.py -> build/bdist.linux-x86_64/wheel/pyqwikswitch
  copying build/lib/pyqwikswitch/async_.py -> build/bdist.linux-x86_64/wheel/pyqwikswitch
  running install_egg_info
  running egg_info
  writing pyqwikswitch.egg-info/PKG-INFO
  writing dependency_links to pyqwikswitch.egg-info/dependency_links.txt
  writing requirements to pyqwikswitch.egg-info/requires.txt
  writing top-level names to pyqwikswitch.egg-info/top_level.txt
  reading manifest file 'pyqwikswitch.egg-info/SOURCES.txt'
  writing manifest file 'pyqwikswitch.egg-info/SOURCES.txt'
  Copying pyqwikswitch.egg-info to build/bdist.linux-x86_64/wheel/pyqwikswitch-0.7-py3.6.egg-info
  running install_scripts
  error: [Errno 2] No such file or directory: 'LICENSE'
  
  ----------------------------------------
  Failed building wheel for pyqwikswitch
  Running setup.py clean for pyqwikswitch
Failed to build pyqwikswitch
Installing collected packages: attrs, idna, certifi, chardet, urllib3, requests, pyqwikswitch
  Running setup.py install for pyqwikswitch ... done
Successfully installed attrs-17.4.0 certifi-2018.1.18 chardet-3.0.4 idna-2.6 pyqwikswitch-0.7 requests-2.18.4 urllib3-1.22
```

**Build log when installing the fixed tarball.**
```
(pyqwikswitch) martin@martin-ThinkPad-T460s:~/Dev/pyqwikswitch$ pip install ~/Skrivbord/test/pyqwikswitch-0.7_manifest.tar.gz 
Processing /home/martin/Skrivbord/test/pyqwikswitch-0.7_manifest.tar.gz
Collecting attrs (from pyqwikswitch==0.7)
  Using cached attrs-17.4.0-py2.py3-none-any.whl
Collecting requests (from pyqwikswitch==0.7)
  Using cached requests-2.18.4-py2.py3-none-any.whl
Collecting idna<2.7,>=2.5 (from requests->pyqwikswitch==0.7)
  Using cached idna-2.6-py2.py3-none-any.whl
Collecting urllib3<1.23,>=1.21.1 (from requests->pyqwikswitch==0.7)
  Using cached urllib3-1.22-py2.py3-none-any.whl
Collecting chardet<3.1.0,>=3.0.2 (from requests->pyqwikswitch==0.7)
  Using cached chardet-3.0.4-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests->pyqwikswitch==0.7)
  Using cached certifi-2018.1.18-py2.py3-none-any.whl
Building wheels for collected packages: pyqwikswitch
  Running setup.py bdist_wheel for pyqwikswitch ... done
  Stored in directory: /home/martin/.cache/pip/wheels/ce/c8/b9/0ecb7ad3b3a1e785f137feddbae147672299efb48ed9e5d757
Successfully built pyqwikswitch
Installing collected packages: attrs, idna, urllib3, chardet, certifi, requests, pyqwikswitch
Successfully installed attrs-17.4.0 certifi-2018.1.18 chardet-3.0.4 idna-2.6 pyqwikswitch-0.7 requests-2.18.4 urllib3-1.22
```